### PR TITLE
Fix for Chisels and Bits

### DIFF
--- a/patchouli_books/leafing/en_us/entries/deco/chiselandbits.json
+++ b/patchouli_books/leafing/en_us/entries/deco/chiselandbits.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "spotlight",
-      "item": "chisel",
+      "item": "chiselsandbits:chisel_stone",
       "text": "$(li)$(bold)$(lmb): Use the chisel in current mode$(li)$(bold)$(lmb)$(bold)+Alt$(): Open Chisel Menu$(li)$(bold)Shift+Scroll$(): Cycle through the modes"
     },
     {
@@ -19,7 +19,7 @@
     },
     {
       "type": "spotlight",
-      "item": "saw",
+      "item": "chiselsandbits:bitsaw_stone",
       "text": "Can be used in the crafting table to cut blocks in half."
     },
     {


### PR DESCRIPTION
changed 2 spotlight items with the correct id because of crashing.